### PR TITLE
SDFE-10202 Protect the 'immutable' types in the Value class

### DIFF
--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AddTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AddTree.java
@@ -43,14 +43,14 @@ public final class AddTree extends AbstractTree
   public Value evaluate (final Context context, final int top) throws SAXException
   {
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v2.type == Value.EMPTY)
+    if (v2.type() == Value.EMPTY)
       return v2;
 
     if (m_aLeft == null) // positive sign
       return new Value (v2.getNumberValue ());
 
     final Value v1 = m_aLeft.evaluate (context, top);
-    if (v1.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY)
       return v1;
     return new Value (v1.getNumberValue () + v2.getNumberValue ());
   }

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrLocalWildcardTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrLocalWildcardTree.java
@@ -82,7 +82,7 @@ public final class AttrLocalWildcardTree extends AbstractTree
     if (m_aLeft != null)
     { // preceding path
       v1 = m_aLeft.evaluate (context, top);
-      if (v1.type == Value.EMPTY)
+      if (v1.type() == Value.EMPTY)
         return v1;
     }
     else
@@ -122,13 +122,13 @@ public final class AttrLocalWildcardTree extends AbstractTree
                                                              e.m_aAttrs.getQName (i),
                                                              e.m_aAttrs.getValue (i)));
           if (last != null)
-            last.next = v2;
+            last.next(v2);
           else
             ret = v2;
           last = v2;
         }
       } // for
-      v1 = v1.next; // next node
+      v1 = v1.next(); // next node
     } while (v1 != null);
 
     if (ret != null)

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrTree.java
@@ -92,14 +92,14 @@ public final class AttrTree extends AbstractTree
     if (m_aLeft != null)
     { // preceding path
       Value v1 = m_aLeft.evaluate (context, top);
-      if (v1.type == Value.EMPTY)
+      if (v1.type() == Value.EMPTY)
         return Value.VAL_EMPTY;
 
       // iterate through this node sequence
       Value ret = null, last = null; // for constructing the result seq
       while (v1 != null)
       {
-        if (v1.type != Value.NODE)
+        if (v1.type() != Value.NODE)
         {
           context.m_aErrorHandler.error ("Current item for evaluating '@" +
                                       m_aValue +
@@ -123,12 +123,12 @@ public final class AttrTree extends AbstractTree
                                                              a.getQName (index),
                                                              a.getValue (index)));
           if (last != null)
-            last.next = v2;
+            last.next(v2);
           else
             ret = v2;
           last = v2;
         }
-        v1 = v1.next; // next node
+        v1 = v1.next(); // next node
       } // while (v1 != null)
 
       if (ret == null)

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrUriWildcardTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrUriWildcardTree.java
@@ -74,7 +74,7 @@ public final class AttrUriWildcardTree extends AbstractTree
     if (m_aLeft != null)
     { // preceding path
       v1 = m_aLeft.evaluate (context, top);
-      if (v1.type == Value.EMPTY)
+      if (v1.type() == Value.EMPTY)
         return v1;
     }
     else
@@ -113,13 +113,13 @@ public final class AttrUriWildcardTree extends AbstractTree
                                                              e.m_aAttrs.getQName (i),
                                                              e.m_aAttrs.getValue (i)));
           if (last != null)
-            last.next = v2;
+            last.next(v2);
           else
             ret = v2;
           last = v2;
         }
       } // for
-      v1 = v1.next; // next node
+      v1 = v1.next(); // next node
     } while (v1 != null);
 
     if (ret != null)

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrWildcardTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/AttrWildcardTree.java
@@ -65,7 +65,7 @@ public final class AttrWildcardTree extends AbstractTree
     if (m_aLeft != null)
     { // preceding path
       v1 = m_aLeft.evaluate (context, top);
-      if (v1.type == Value.EMPTY)
+      if (v1.type() == Value.EMPTY)
         return v1;
     }
     else
@@ -99,12 +99,12 @@ public final class AttrWildcardTree extends AbstractTree
       {
         final Value v2 = new Value (SAXEvent.newAttribute (e.m_aAttrs, i));
         if (last != null)
-          last.next = v2;
+          last.next(v2);
         else
           ret = v2;
         last = v2;
       } // for
-      v1 = v1.next; // next node
+      v1 = v1.next(); // next node
     } while (v1 != null);
 
     if (ret != null)

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/DescTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/DescTree.java
@@ -69,7 +69,7 @@ public final class DescTree extends AbstractReversableTree
     while (top < context.ancestorStack.size ())
     {
       final Value v1 = m_aRight.evaluate (context, top++);
-      if (v1.type == Value.NODE)
+      if (v1.type() == Value.NODE)
       {
         if (ret != null)
         {
@@ -78,22 +78,22 @@ public final class DescTree extends AbstractReversableTree
           while (vi != null)
           {
             Value vj;
-            for (vj = ret; vj != null; vj = vj.next)
+            for (vj = ret; vj != null; vj = vj.next())
               if (vi.getNode () == vj.getNode ())
                 break;
             if (vj == null)
             { // vi not found in ret
-              last.next = vi;
+              last.next(vi);
               last = vi;
             }
-            vi = vi.next;
-            last.next = null; // because last=vi above
+            vi = vi.next();
+            last.next(null); // because last=vi above
           }
         }
         else
         {
           ret = v1;
-          for (last = v1; last.next != null; last = last.next)
+          for (last = v1; last.next() != null; last = last.next())
           {}
         }
       }

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/DivTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/DivTree.java
@@ -43,11 +43,11 @@ public final class DivTree extends AbstractTree
   public Value evaluate (final Context context, final int top) throws SAXException
   {
     final Value v1 = m_aLeft.evaluate (context, top);
-    if (v1.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY)
       return v1;
 
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v2.type == Value.EMPTY)
+    if (v2.type() == Value.EMPTY)
       return v2;
 
     // none of the operands is empty, ok: perform the operation

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/EqTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/EqTree.java
@@ -44,21 +44,21 @@ public final class EqTree extends AbstractTree
   {
     final Value v1 = m_aLeft.evaluate (context, top);
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v1.type == Value.EMPTY || v2.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY || v2.type() == Value.EMPTY)
       return Value.VAL_FALSE;
 
     // sequences: find a pair such that the comparison is true
-    for (Value vi = v1; vi != null; vi = vi.next)
+    for (Value vi = v1; vi != null; vi = vi.next())
     {
-      for (Value vj = v2; vj != null; vj = vj.next)
+      for (Value vj = v2; vj != null; vj = vj.next())
       {
-        if (vi.type == Value.BOOLEAN || vj.type == Value.BOOLEAN)
+        if (vi.type() == Value.BOOLEAN || vj.type() == Value.BOOLEAN)
         {
           if (vi.getBooleanValue () == vj.getBooleanValue ())
             return Value.VAL_TRUE;
         }
         else
-          if (vi.type == Value.NUMBER || vj.type == Value.NUMBER)
+          if (vi.type() == Value.NUMBER || vj.type() == Value.NUMBER)
           {
             if (vi.getNumberValue () == vj.getNumberValue ())
               return Value.VAL_TRUE;

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/GeTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/GeTree.java
@@ -44,13 +44,13 @@ public final class GeTree extends AbstractTree
   {
     final Value v1 = m_aLeft.evaluate (context, top);
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v1.type == Value.EMPTY || v2.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY || v2.type() == Value.EMPTY)
       return Value.VAL_FALSE;
 
     // sequences: find a pair that the comparison is true
-    for (Value vi = v1; vi != null; vi = vi.next)
+    for (Value vi = v1; vi != null; vi = vi.next())
     {
-      for (Value vj = v2; vj != null; vj = vj.next)
+      for (Value vj = v2; vj != null; vj = vj.next())
       {
         if (vi.getNumberValue () >= vj.getNumberValue ())
           return Value.VAL_TRUE;

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/GtTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/GtTree.java
@@ -44,13 +44,13 @@ public final class GtTree extends AbstractTree
   {
     final Value v1 = m_aLeft.evaluate (context, top);
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v1.type == Value.EMPTY || v2.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY || v2.type() == Value.EMPTY)
       return Value.VAL_FALSE;
 
     // sequences: find a pair that the comparison is true
-    for (Value vi = v1; vi != null; vi = vi.next)
+    for (Value vi = v1; vi != null; vi = vi.next())
     {
-      for (Value vj = v2; vj != null; vj = vj.next)
+      for (Value vj = v2; vj != null; vj = vj.next())
       {
         if (vi.getNumberValue () > vj.getNumberValue ())
           return Value.VAL_TRUE;

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/LeTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/LeTree.java
@@ -44,13 +44,13 @@ public final class LeTree extends AbstractTree
   {
     final Value v1 = m_aLeft.evaluate (context, top);
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v1.type == Value.EMPTY || v2.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY || v2.type() == Value.EMPTY)
       return Value.VAL_FALSE;
 
     // sequences: find a pair that the comparison is true
-    for (Value vi = v1; vi != null; vi = vi.next)
+    for (Value vi = v1; vi != null; vi = vi.next())
     {
-      for (Value vj = v2; vj != null; vj = vj.next)
+      for (Value vj = v2; vj != null; vj = vj.next())
       {
         if (vi.getNumberValue () <= vj.getNumberValue ())
           return Value.VAL_TRUE;

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/LtTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/LtTree.java
@@ -44,13 +44,13 @@ public final class LtTree extends AbstractTree
   {
     final Value v1 = m_aLeft.evaluate (context, top);
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v1.type == Value.EMPTY || v2.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY || v2.type() == Value.EMPTY)
       return Value.VAL_FALSE;
 
     // sequences: find a pair that the comparison is true
-    for (Value vi = v1; vi != null; vi = vi.next)
+    for (Value vi = v1; vi != null; vi = vi.next())
     {
-      for (Value vj = v2; vj != null; vj = vj.next)
+      for (Value vj = v2; vj != null; vj = vj.next())
       {
         if (vi.getNumberValue () < vj.getNumberValue ())
           return Value.VAL_TRUE;

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/ModTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/ModTree.java
@@ -43,11 +43,11 @@ public final class ModTree extends AbstractTree
   public Value evaluate (final Context context, final int top) throws SAXException
   {
     final Value v1 = m_aLeft.evaluate (context, top);
-    if (v1.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY)
       return v1;
 
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v2.type == Value.EMPTY)
+    if (v2.type() == Value.EMPTY)
       return v2;
 
     // none of the operands is empty, ok: perform the operation

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/MultTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/MultTree.java
@@ -43,11 +43,11 @@ public final class MultTree extends AbstractTree
   public Value evaluate (final Context context, final int top) throws SAXException
   {
     final Value v1 = m_aLeft.evaluate (context, top);
-    if (v1.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY)
       return v1;
 
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v2.type == Value.EMPTY)
+    if (v2.type() == Value.EMPTY)
       return v2;
 
     // none of the operands is empty, ok: perform the operation

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/NeTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/NeTree.java
@@ -44,21 +44,21 @@ public final class NeTree extends AbstractTree
   {
     final Value v1 = m_aLeft.evaluate (context, top);
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v1.type == Value.EMPTY || v2.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY || v2.type() == Value.EMPTY)
       return Value.VAL_FALSE;
 
     // sequences: find a pair that the comparison is true
-    for (Value vi = v1; vi != null; vi = vi.next)
+    for (Value vi = v1; vi != null; vi = vi.next())
     {
-      for (Value vj = v2; vj != null; vj = vj.next)
+      for (Value vj = v2; vj != null; vj = vj.next())
       {
-        if (vi.type == Value.BOOLEAN || vj.type == Value.BOOLEAN)
+        if (vi.type() == Value.BOOLEAN || vj.type() == Value.BOOLEAN)
         {
           if (vi.getBooleanValue () != vj.getBooleanValue ())
             return Value.VAL_TRUE;
         }
         else
-          if (vi.type == Value.NUMBER || vj.type == Value.NUMBER)
+          if (vi.type() == Value.NUMBER || vj.type() == Value.NUMBER)
           {
             if (vi.getNumberValue () != vj.getNumberValue ())
               return Value.VAL_TRUE;

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/PredicateTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/PredicateTree.java
@@ -58,7 +58,7 @@ public final class PredicateTree extends AbstractTree
         m_aLeft.matches (context, top, true))
     {
       final Value v = m_aRight.evaluate (context, top);
-      if (v.type == Value.NUMBER)
+      if (v.type() == Value.NUMBER)
         retValue = (context.position == Math.round (v.getNumberValue ()));
       else
         retValue = v.getBooleanValue ();

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/SeqTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/SeqTree.java
@@ -58,9 +58,9 @@ public final class SeqTree extends AbstractTree
       v2 = Value.VAL_EMPTY;
 
     // if we got an empty sequence, return the other value
-    if (v1.type == Value.EMPTY)
+    if (v1.type() == Value.EMPTY)
       return v2;
-    if (v2.type == Value.EMPTY)
+    if (v2.type() == Value.EMPTY)
       return v1;
 
     return Value.concat (v1, v2);

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/SubTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/SubTree.java
@@ -46,14 +46,14 @@ public final class SubTree extends AbstractTree
     if (m_aLeft != null)
     {
       v1 = m_aLeft.evaluate (context, top);
-      if (v1.type == Value.EMPTY)
+      if (v1.type() == Value.EMPTY)
         return v1;
     }
     else
       v1 = null; // negative sign
 
     final Value v2 = m_aRight.evaluate (context, top);
-    if (v2.type == Value.EMPTY)
+    if (v2.type() == Value.EMPTY)
       return v2;
 
     // none of the operands is empty, ok: perform the operation

--- a/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/VarTree.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/grammar/tree/VarTree.java
@@ -105,7 +105,7 @@ public final class VarTree extends AbstractTree
 
     final Value v1 = vars.get (expName);
     // create a copy if the result is a sequence
-    return v1.next == null ? v1 : v1.copy ();
+    return v1.next() == null ? v1 : v1.copy ();
   }
 
   @Override

--- a/ph-stx-engine/src/main/java/net/sf/joost/instruction/ForEachFactory.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/instruction/ForEachFactory.java
@@ -164,7 +164,7 @@ public final class ForEachFactory extends AbstractFactoryBase
         selectResult = m_aSelect.evaluate (context, this);
       }
 
-      if (selectResult == null || selectResult.type == Value.EMPTY)
+      if (selectResult == null || selectResult.type() == Value.EMPTY)
       {
         // for-each-item finished (empty sequence left)
         next = successor;
@@ -172,8 +172,8 @@ public final class ForEachFactory extends AbstractFactoryBase
       }
 
       super.process (context); // enter new scope for local variables
-      m_aResultStack.push (selectResult.next);
-      selectResult.next = null;
+      m_aResultStack.push (selectResult.next());
+      selectResult.next(null);
 
       context.localVars.put (m_sExpName, selectResult);
       declareVariable (m_sExpName);

--- a/ph-stx-engine/src/main/java/net/sf/joost/instruction/PDocumentFactory.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/instruction/PDocumentFactory.java
@@ -141,7 +141,7 @@ public class PDocumentFactory extends AbstractFactoryBase
     public short processEnd (final Context context) throws SAXException
     {
       Value v = m_aHref.evaluate (context, this);
-      if (v.type == Value.EMPTY)
+      if (v.type() == Value.EMPTY)
         return CSTX.PR_CONTINUE; // nothing to do
 
       final Processor proc = context.currentProcessor;
@@ -161,7 +161,7 @@ public class PDocumentFactory extends AbstractFactoryBase
       if (m_aBaseUri == null)
       {
         // determine default base URI
-        if (v.type == Value.NODE)
+        if (v.type() == Value.NODE)
         {
           // use #input
           base = context.locator.getSystemId ();
@@ -195,8 +195,8 @@ public class PDocumentFactory extends AbstractFactoryBase
           XMLReader reader;
           InputSource iSource;
           Source source;
-          nextVal = v.next;
-          v.next = null;
+          nextVal = v.next();
+          v.next(null);
           final String hrefURI = v.getStringValue ();
           // ask URI resolver if present
           if (context.m_aURIResolver != null && (source = context.m_aURIResolver.resolve (hrefURI, base)) != null)

--- a/ph-stx-engine/src/main/java/net/sf/joost/instruction/ValueOfFactory.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/instruction/ValueOfFactory.java
@@ -100,7 +100,7 @@ public final class ValueOfFactory extends AbstractFactoryBase
     {
       Value v = m_aSelect.evaluate (context, this);
       String s;
-      if (v.next == null)
+      if (v.next() == null)
         s = v.getStringValue ();
       else
       {
@@ -110,15 +110,15 @@ public final class ValueOfFactory extends AbstractFactoryBase
         // value
         // use a string buffer for creating the result
         final StringBuilder sb = new StringBuilder ();
-        Value nextVal = v.next;
-        v.next = null;
+        Value nextVal = v.next();
+        v.next(null);
         sb.append (v.getStringValue ());
         while (nextVal != null)
         {
           sb.append (sep);
           v = nextVal;
-          nextVal = v.next;
-          v.next = null;
+          nextVal = v.next();
+          v.next(null);
           sb.append (v.getStringValue ());
         }
         s = sb.toString ();

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/TransformerHandlerResolverImpl.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/TransformerHandlerResolverImpl.java
@@ -199,7 +199,7 @@ public final class TransformerHandlerResolverImpl
       // remove preceding "{}" if present
       final String name = key.startsWith ("{}") ? key.substring (2) : key;
       final Value val = params.get (key);
-      result.put (name, val.type == Value.OBJECT ? val.getObject () : val.getStringValue ());
+      result.put (name, val.type() == Value.OBJECT ? val.getObject () : val.getStringValue ());
     }
     return result;
   }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/Value.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/Value.java
@@ -63,7 +63,7 @@ public final class Value implements Cloneable
   public static final int OBJECT = 5;
 
   /** type of this value */
-  public int type;
+  private int type;
 
   /** for <code>{@link #type} == {@link #NODE}</code> */
   private SAXEvent event;
@@ -86,7 +86,7 @@ public final class Value implements Cloneable
    * {@link #NODE} and {@link #event} set to <code>null</code>
    * (<code>next</code> must be <code>null</code> in this case, too).
    */
-  public Value next;
+  private Value next;
 
   //
   // Constructors
@@ -178,6 +178,37 @@ public final class Value implements Cloneable
   //
   // Methods
   //
+
+  // Attempt to provide some protection around the type values that should be immutable.
+
+  public int type() {
+    return type;
+  }
+
+  public Value next() {
+    return next;
+  }
+
+  public void next(final Value next) {
+    if(type == EMPTY || isImmutableValue()) {
+      throw new UnsupportedOperationException("Cannot modify the immutable constant types");
+    }
+    this.next = next;
+  }
+
+  public boolean isMutableValue() {
+    return !isImmutableValue();
+  }
+
+  private boolean isImmutableValue() {
+    return VAL_TRUE.equals(this) ||
+            VAL_FALSE.equals(this) ||
+            VAL_EMPTY.equals(this) ||
+            VAL_EMPTY_STRING.equals(this) ||
+            VAL_ZERO.equals(this) ||
+            VAL_NAN.equals(this);
+  }
+
 
   // Getter
 

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Avg.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Avg.java
@@ -63,13 +63,13 @@ public final class Avg implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY) // empty sequence
+    if (v.type() == Value.EMPTY) // empty sequence
       return v;
     double avg = 0;
     int count = 0;
     while (v != null)
     {
-      final Value next = v.next;
+      final Value next = v.next();
       avg += v.getNumberValue ();
       count++;
       v = next;

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Ceiling.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Ceiling.java
@@ -66,7 +66,7 @@ public final class Ceiling implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY)
+    if (v.type() == Value.EMPTY)
       return v;
     return new Value (Math.ceil (v.getNumberValue ()));
   }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Count.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Count.java
@@ -66,13 +66,13 @@ public final class Count implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY) // empty sequence
+    if (v.type() == Value.EMPTY) // empty sequence
       return Value.VAL_ZERO;
     int count = 1;
-    while (v.next != null)
+    while (v.next() != null)
     {
       count++;
-      v = v.next;
+      v = v.next();
     }
     return new Value (count);
   }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Empty.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Empty.java
@@ -67,6 +67,6 @@ public final class Empty implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = args.evaluate (context, top);
-    return Value.getBoolean (v.type == Value.EMPTY);
+    return Value.getBoolean (v.type() == Value.EMPTY);
   }
 }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Exists.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Exists.java
@@ -67,6 +67,6 @@ public final class Exists implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = args.evaluate (context, top);
-    return Value.getBoolean (v.type != Value.EMPTY);
+    return Value.getBoolean (v.type() != Value.EMPTY);
   }
 }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/ExtSequence.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/ExtSequence.java
@@ -68,7 +68,7 @@ public final class ExtSequence implements IInstance
   {
     Value v = args.evaluate (context, top);
     // in case there's no object
-    if (v.type != Value.OBJECT)
+    if (v.type() != Value.OBJECT)
       return v;
 
     Object [] objs = null;
@@ -91,8 +91,8 @@ public final class ExtSequence implements IInstance
       Value last = v;
       for (int i = 1; i < objs.length; i++)
       {
-        last.next = new Value (objs[i]);
-        last = last.next;
+        last.next(new Value (objs[i]));
+        last = last.next();
       }
     }
 

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Floor.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Floor.java
@@ -66,7 +66,7 @@ public final class Floor implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY)
+    if (v.type() == Value.EMPTY)
       return v;
     return new Value (Math.floor (v.getNumberValue ()));
   }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/GetInScopePrefixes.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/GetInScopePrefixes.java
@@ -84,7 +84,7 @@ public final class GetInScopePrefixes implements IInstance
     {
       v = new Value (en);
       if (last != null)
-        last.next = v;
+        last.next(v);
       else
         ret = v;
       last = v;

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/IndexOf.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/IndexOf.java
@@ -77,12 +77,11 @@ public final class IndexOf implements IInstance
 
     final AbstractTree tSeq = new ValueTree (seq);
 
-    // TODO Guard around the supposed "Immutable" types in Value, but allow current behaviour for others ...
-    // This seems like thoroughly dangerous behaviour though. We're modifying a caller value in a function
-    // that does not indicate modification of this parameter.
-    if(item.isMutableValue()) {
-      item.next(null);
+    // We shouldn't be mutating sequence values, so break out now
+    if(item.next() != null) {
+      throw new IllegalArgumentException("item parameter should not be a sequence");
     }
+
     final AbstractTree tItem = new ValueTree (item);
     // use the implemented = semantics
     final AbstractTree equals = new EqTree (tSeq, tItem);

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/InsertBefore.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/InsertBefore.java
@@ -80,9 +80,9 @@ public final class InsertBefore implements IInstance
                                "'");
     long position = Math.round (dPos);
 
-    if (inserts.type == Value.EMPTY)
+    if (inserts.type() == Value.EMPTY)
       return target;
-    if (target.type == Value.EMPTY)
+    if (target.type() == Value.EMPTY)
       return inserts;
 
     Value result;
@@ -93,16 +93,16 @@ public final class InsertBefore implements IInstance
     {
       result = target;
       // determine position
-      while (target.next != null && --position > 1)
-        target = target.next;
-      final Value rest = target.next;
-      target.next = inserts;
+      while (target.next() != null && --position > 1)
+        target = target.next();
+      final Value rest = target.next();
+      target.next(inserts);
       target = rest;
     }
     // append rest of target
-    while (inserts.next != null)
-      inserts = inserts.next;
-    inserts.next = target;
+    while (inserts.next() != null)
+      inserts = inserts.next();
+    inserts.next(target);
 
     return result;
   }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/ItemAt.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/ItemAt.java
@@ -67,12 +67,12 @@ public final class ItemAt implements IInstance
     Value seq = args.m_aLeft.evaluate (context, top);
     final double dpos = args.m_aRight.evaluate (context, top).getNumberValue ();
 
-    if (seq.type == Value.EMPTY || Double.isNaN (dpos))
+    if (seq.type() == Value.EMPTY || Double.isNaN (dpos))
       return Value.VAL_EMPTY;
 
     long position = Math.round (dpos);
     while (seq != null && --position != 0)
-      seq = seq.next;
+      seq = seq.next();
 
     if (seq == null)
       throw new EvalException ("Position " +

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/LocalName.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/LocalName.java
@@ -67,7 +67,7 @@ public final class LocalName implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = FunctionFactory.getOptionalValue (context, top, args);
-    if (v.type == Value.EMPTY)
+    if (v.type() == Value.EMPTY)
       return Value.VAL_EMPTY_STRING;
 
     final SAXEvent event = v.getNode ();

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Max.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Max.java
@@ -64,12 +64,12 @@ public final class Max implements IInstance
                                                                                         EvalException
   {
     Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY) // empty sequence
+    if (v.type() == Value.EMPTY) // empty sequence
       return v;
     double max = Double.NEGATIVE_INFINITY;
     while (v != null)
     {
-      final Value next = v.next;
+      final Value next = v.next();
       final double n = v.getNumberValue ();
       if (Double.isNaN (n))
         return Value.VAL_NAN;

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Min.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Min.java
@@ -64,12 +64,12 @@ public final class Min implements IInstance
                                                                                         EvalException
   {
     Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY) // empty sequence
+    if (v.type() == Value.EMPTY) // empty sequence
       return v;
     double min = Double.POSITIVE_INFINITY;
     while (v != null)
     {
-      final Value next = v.next;
+      final Value next = v.next();
       final double n = v.getNumberValue ();
       if (Double.isNaN (n))
         return Value.VAL_NAN;

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Name.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Name.java
@@ -67,7 +67,7 @@ public final class Name implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = FunctionFactory.getOptionalValue (context, top, args);
-    if (v.type == Value.EMPTY)
+    if (v.type() == Value.EMPTY)
       return Value.VAL_EMPTY_STRING;
     final SAXEvent event = v.getNode ();
     if (event == null)

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/NamespaceURI.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/NamespaceURI.java
@@ -69,7 +69,7 @@ public final class NamespaceURI implements IInstance
                                                                                         EvalException
   {
     final Value v = FunctionFactory.getOptionalValue (context, top, args);
-    if (v.type == Value.EMPTY)
+    if (v.type() == Value.EMPTY)
       return Value.VAL_EMPTY_STRING;
 
     final SAXEvent event = v.getNode ();

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/NodeKind.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/NodeKind.java
@@ -64,7 +64,7 @@ public final class NodeKind implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY)
+    if (v.type() == Value.EMPTY)
       return v;
 
     final SAXEvent event = v.getNode ();

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Remove.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Remove.java
@@ -80,7 +80,7 @@ public final class Remove implements IInstance
                                "'");
     long position = Math.round (dPos);
 
-    if (seq.type == Value.EMPTY || position < 1)
+    if (seq.type() == Value.EMPTY || position < 1)
       return seq;
 
     Value last = null;
@@ -88,7 +88,7 @@ public final class Remove implements IInstance
     while (seq != null && --position != 0)
     {
       last = seq;
-      seq = seq.next;
+      seq = seq.next();
     }
 
     if (seq == null) // position greater than sequence length
@@ -97,12 +97,12 @@ public final class Remove implements IInstance
     if (last == null)
     {
       // remove the first item
-      if (result.next == null) // the one and only item
+      if (result.next() == null) // the one and only item
         return Value.VAL_EMPTY;
-      return result.next;
+      return result.next();
     }
 
-    last.next = seq.next;
+    last.next(seq.next());
     return result;
   }
 }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Round.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Round.java
@@ -66,7 +66,7 @@ public final class Round implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     final Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY)
+    if (v.type() == Value.EMPTY)
       return v;
     final double n = v.getNumberValue ();
     // test for special cases

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/StringJoin.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/StringJoin.java
@@ -68,12 +68,12 @@ public final class StringJoin implements IInstance
   {
     Value seq = args.m_aLeft.evaluate (context, top);
     final String sep = args.m_aRight.evaluate (context, top).getStringValue ();
-    if (seq.type == Value.EMPTY)
+    if (seq.type() == Value.EMPTY)
       return Value.VAL_EMPTY_STRING;
     final StringBuffer buf = new StringBuffer ();
     while (seq != null)
     {
-      final Value next = seq.next;
+      final Value next = seq.next();
       buf.append (seq.getStringValue ());
       if (next != null)
         buf.append (sep);

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Subsequence.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Subsequence.java
@@ -77,7 +77,7 @@ public final class Subsequence implements IInstance
       final double arg3 = args.m_aRight.evaluate (context, top).getNumberValue ();
 
       // extra test, because round(NaN) gives 0
-      if (seq.type == Value.EMPTY || Double.isNaN (arg2) || Double.isNaN (arg2 + arg3))
+      if (seq.type() == Value.EMPTY || Double.isNaN (arg2) || Double.isNaN (arg2 + arg3))
         return Value.VAL_EMPTY;
 
       // the first item is at position 1
@@ -93,7 +93,7 @@ public final class Subsequence implements IInstance
       seq = args.m_aLeft.evaluate (context, top);
       final double arg2 = args.m_aRight.evaluate (context, top).getNumberValue ();
 
-      if (seq.type == Value.EMPTY || Double.isNaN (arg2))
+      if (seq.type() == Value.EMPTY || Double.isNaN (arg2))
         return Value.VAL_EMPTY;
       if (arg2 < 1)
         return seq;
@@ -117,12 +117,12 @@ public final class Subsequence implements IInstance
       end--;
       if (end == 0)
         break;
-      seq = seq.next;
+      seq = seq.next();
     }
     if (ret != null)
     {
       if (end == 0) // reached the end of the requested subsequence
-        seq.next = null; // cut the rest
+        seq.next(null); // cut the rest
       return ret;
     }
     return Value.VAL_EMPTY;

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Sum.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Sum.java
@@ -66,12 +66,12 @@ public final class Sum implements IInstance
   public Value evaluate (final Context context, final int top, final AbstractTree args) throws SAXException, EvalException
   {
     Value v = args.evaluate (context, top);
-    if (v.type == Value.EMPTY) // empty sequence
+    if (v.type() == Value.EMPTY) // empty sequence
       return Value.VAL_ZERO;
     double sum = 0;
     while (v != null)
     {
-      final Value next = v.next;
+      final Value next = v.next();
       sum += v.getNumberValue ();
       v = next;
     }

--- a/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Tokenize.java
+++ b/ph-stx-engine/src/main/java/net/sf/joost/stx/function/Tokenize.java
@@ -116,7 +116,7 @@ public final class Tokenize implements IInstance
         start = last = current;
       else
       {
-        last.next = current;
+        last.next(current);
         last = current;
       }
     } while (prevEnd > 0);


### PR DESCRIPTION
The `type` and `next` properties on `net.sf.joost.stx.Value` were publicly mutable. What this meant is that the following `static` values:

* `VAL_TRUE`
* `VAL_FALSE`
* `VAL_EMPTY`
* `VAL_EMPTY_STRING`
* `VAL_ZERO`
* `VAL_NAN`

could accidentally be mutated. This is most noticable when you're using sequences of immutable types like `true()`, ie:
```
<stx:variable name="my-seq" select="(true(), false(), true())"/>
```

The problem here is that functions like `insert-before()` will mutate the values of the sequence, ergo mutating the immutable instances. Mutation of the sequence is expected, however mutation of the immutable values declared is an unexpected side-effect.

It gets somewhat worse in that functions like `index-of` will also mutate parameters. So if you have a statement like:
```
<stx:variable name="my-true-values" select="index-of($my-seq, true())"/>
```
Then the `index-of` function will attempt to mutate the `next` property of your second parameter `true()`, which should be immutable. It attempts to set `next` to `null`, which we expect. So this is not _too_ bad. It shouldn't happen though.